### PR TITLE
proof gen: fix type mismatch with nodejs buffer

### DIFF
--- a/build/wasmsnark_bn128.js
+++ b/build/wasmsnark_bn128.js
@@ -5645,9 +5645,9 @@ class Bn128 {
             this.putBin(ps, rnd);
         } else {
             const br = NodeCrypto.randomBytes(32);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
             const bs = NodeCrypto.randomBytes(32);
-            this.putBin(ps, bs);
+            this.putBin(ps, new Uint8Array(bs.buffer));
         }
 
 /// Uncoment it to debug and check it works

--- a/build/wasmsnark_mnt6753.js
+++ b/build/wasmsnark_mnt6753.js
@@ -6360,7 +6360,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 
@@ -6525,7 +6525,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 

--- a/example/bn128/wasmsnark_bn128.js
+++ b/example/bn128/wasmsnark_bn128.js
@@ -5645,9 +5645,9 @@ class Bn128 {
             this.putBin(ps, rnd);
         } else {
             const br = NodeCrypto.randomBytes(32);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
             const bs = NodeCrypto.randomBytes(32);
-            this.putBin(ps, bs);
+            this.putBin(ps, new Uint8Array(bs.buffer));
         }
 
 /// Uncoment it to debug and check it works

--- a/example/mnt6753/wasmsnark_mnt6753.js
+++ b/example/mnt6753/wasmsnark_mnt6753.js
@@ -6360,7 +6360,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 
@@ -6525,7 +6525,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 

--- a/src/bn128.js
+++ b/src/bn128.js
@@ -655,9 +655,9 @@ class Bn128 {
             this.putBin(ps, rnd);
         } else {
             const br = NodeCrypto.randomBytes(32);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
             const bs = NodeCrypto.randomBytes(32);
-            this.putBin(ps, bs);
+            this.putBin(ps, new Uint8Array(bs.buffer));
         }
 
 /// Uncoment it to debug and check it works

--- a/src/mnt6753.js
+++ b/src/mnt6753.js
@@ -796,7 +796,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 
@@ -961,7 +961,7 @@ class Mnt6753 {
             this.putBin(pr, rnd);
         } else {
             br = NodeCrypto.randomBytes(16);
-            this.putBin(pr, br);
+            this.putBin(pr, new Uint8Array(br.buffer));
         }
 
 


### PR DESCRIPTION
First `if` clause emits Uint8Array while `else` emits `Buffer`, which are different.

The change ensures Uint8Array is always used.